### PR TITLE
fix: case-sensitive bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       {
         "label": "Boitatech",
         "uiTheme": "vs-dark",
-        "path": "./themes/Boitatech.json"
+        "path": "./themes/boitatech.json"
       }
     ]
   },


### PR DESCRIPTION
Este PR corrige o probleminha de case que está dando no Linux.

A extensão está buscando Boitatech.json mas o arquivo está como boitatech.json.

![image](https://user-images.githubusercontent.com/46503804/193864343-85d05c4d-dc6e-42cb-8c43-7e795a599395.png)
![image](https://user-images.githubusercontent.com/46503804/193864373-0393fd20-6e84-4cbe-aca2-44480a21099c.png)
